### PR TITLE
Use postgreSQL for testing as well.

### DIFF
--- a/.envs/.local/.postgres
+++ b/.envs/.local/.postgres
@@ -1,7 +1,13 @@
-# PostgreSQL
-# ----------------------------
+# POSTGRESQL DEV DATABASE
+# ---------------------------------------
 POSTGRES_HOST=postgres
 POSTGRES_PORT=5432
 POSTGRES_DB=bloodhound
 POSTGRES_USER=dev
 POSTGRES_PASSWORD=changeme407
+
+# POSTGRESQL TEST DATABASE
+# ---------------------------------------
+POSTGRES_DB_TEST=bloodgound_test
+POSTGRES_USER_TEST=postgres
+POSTGRES_PASSWORD_TEST=postgres

--- a/config/settings/test.py
+++ b/config/settings/test.py
@@ -7,12 +7,16 @@ import sys
 from .base import *  # noqa: F403
 from .base import TEMPLATES
 
-TEST_DATABASE_PREFIX = "test_"
 
-# Switch to Sqlite3 for testing purposes.
+# DATABASES
+# ------------------------------------------------------------------------------
+# https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {
     "default": {
-        "ENGINE": "django.db.backends.sqlite3",
+        "ENGINE": "django.db.backends.postgresql",
+        "NAME": os.getenv("POSTGRES_DB_TEST", default="bloodhound_test"),
+        "USER": os.getenv("POSTGRES_USER_TEST", default="postgres"),
+        "PASSWORD": os.getenv("POSTGRES_PASSWORD_TEST", default="postgres"),
     }
 }
 


### PR DESCRIPTION
- Sqlite3 giving issues with the latest django.
-  Revert to usinig postgres for testing as well.
fix #25 